### PR TITLE
fix: remove auto update version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,30 +28,6 @@ jobs:
           tag: ${{ steps.bumper.outputs.new_version }}
           prefix: v
 
-      - name: Update README major version
-        id: version_count
-        run: echo "::set-output name=count::$(fgrep -c rusty-actions/release-versions@${{ steps.versions.outputs.major_version }} ) README.md"
-
-      - name: Update README usage example
-        if: steps.version_count.outputs.count == 0
-        run: |
-          sed -i 's|uses\: rusty-actions/rusty-actions/dockerfile-linter@.*|uses\: rusty-actions/rusty-actions/dockerfile-linter@${{ steps.versions.outputs.major_version }}|g' README.md
-
-      - name: Configure git
-        if: steps.version_count.outputs.count == 0
-        run: |
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
-
-      - name: Push modifications
-        if: steps.version_count.outputs.count == 0
-        run: |
-          if [[ ! $(git diff --quiet) ]]; then
-            git add README.md
-            git commit -m "docs: update README usage section with v${{ steps.bumper.outputs.major_part }} [skip ci]"
-            git push
-          fi
-
       - name: Create tag
         uses: rickstaa/action-create-tag@v1
         with:


### PR DESCRIPTION
# Pull Request Form

**What does this PR do and why we need it**:

This PR removes the auto update of the documentation on major release change. This is not required as a major release indicates a breaking change and therefore documentation also needs to be sufficiently updated.

**Is your branch up to date with main?**:

Yes

[X] Branch is up to date with main at time of PR

**What type of PR is this?**

> Select only one `commit category` enter 'X'

**Commit Category**

> [ ] bug fix
> [ ] feature
> [ ] testing
> [ ] document
> [X] workflow

**Please ensure there is an issue for the change, if not create one of the apropriate type**:

> Format: `https://github.com/rusty-apps/<REPOSITORY>/issues/<ISSUE_NUMBER>`

Fixes Issue: [<?>]

**Have you updated the necessary documentation?**

- [ ] Documentation update is required by this PR.
- [ ] Documentation has been updated.

**The changes have been linted**
- [ ]

**The code has been tested**

- [ ] Additional tests added for this code change.
- [ ] Code has been tested and all tests passed.

**How to test changes / Special notes to the reviewer**:
